### PR TITLE
Replace layout logo with text-based branding

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,3 +1,6 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+
 import "./../styles/globals.css";
 
 export const metadata = {
@@ -5,11 +8,41 @@ export const metadata = {
   description: "Gioco d’acquisto stile Tinder",
 };
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+type RootLayoutProps = {
+  children: ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
   return (
     <html lang="it">
       <body>
-        <main style={{maxWidth: "720px", margin: "0 auto", padding: "24px"}}>
+        <header
+          style={{
+            maxWidth: "720px",
+            margin: "0 auto",
+            padding: "24px 24px 0",
+          }}
+        >
+          <Link
+            href="/"
+            aria-label="Can You Makeup homepage"
+            style={{
+              display: "inline-flex",
+              alignItems: "baseline",
+              gap: "0.35ch",
+              fontSize: "1.5rem",
+              fontWeight: 700,
+              letterSpacing: "0.08em",
+              textTransform: "uppercase",
+              lineHeight: 1.1,
+            }}
+          >
+            <span style={{ color: "#111" }}>Can</span>
+            <span style={{ color: "#da3833" }}>You</span>
+            <span style={{ color: "#111" }}>Makeup</span>
+          </Link>
+        </header>
+        <main style={{ maxWidth: "720px", margin: "0 auto", padding: "24px" }}>
           {children}
         </main>
       </body>


### PR DESCRIPTION
## Summary
- replace the logo in `app/layout.tsx` with an inline text-based marque so the binary PNG asset is no longer needed
- add explicit typing for the layout children props while keeping the existing metadata export intact

## Testing
- npm install --package-lock=false *(fails: npm registry returned 403 for @auth/core)*

------
https://chatgpt.com/codex/tasks/task_e_68cab37bfef083239969790f4948236f